### PR TITLE
Fix for multiple whitelisted patterns

### DIFF
--- a/background.js
+++ b/background.js
@@ -68,17 +68,16 @@ browser.storage.local.get('sites').then(({sites}) => {
 browser.webRequest.onHeadersReceived.addListener(
   function(details) {
     const {documentUrl, type, responseHeaders} = details;
-    if (regexes.length == 0) {
-      return {};
-    }
-    for (const regex of regexes) {
-      if (!(documentUrl && type == 'sub_frame' && documentUrl.match(regex))) {
-        return {};
+    if (type == 'sub_frame' && documentUrl) {
+      for (const regex of regexes) {
+        if (documentUrl.match(regex)) {
+          return {
+            responseHeaders: responseHeaders.filter(({name}) => name.toLowerCase() != "x-frame-options"),
+          };
+        }
       }
     }
-    return {
-      responseHeaders: responseHeaders.filter(({name}) => name.toLowerCase() != "x-frame-options"),
-    };
+    return {};
   },
   { urls: ["<all_urls>"] },
   ["blocking", "responseHeaders"]


### PR DESCRIPTION
The core loop originally would allow `X-Frame-Options` if the user specified any pattern that did not match the current URL. In other words, it would remove the header only when all patterns match.

This patch fixes that. At the same time, I moved some checks outside of the loop that don't depend on which regex is being checked.

I also removed the check for an empty array of regexes, on the grounds that the `for` loop will do the same check just as well.

What I have _not_ done is tested any of this. It's purely based on code review and my understanding of the documentation. So please don't merge it blindly. :sweat_smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/anarchist-framer/1)
<!-- Reviewable:end -->
