### PR TITLE
Pre-filter response listener by request type

### DIFF
--- a/background.js
+++ b/background.js
@@ -60,8 +60,8 @@ browser.storage.local.get('sites').then(({sites}) => {
 
 browser.webRequest.onHeadersReceived.addListener(
   function(details) {
-    const {documentUrl, type, responseHeaders} = details;
-    if (type == 'sub_frame' && documentUrl) {
+    const {documentUrl, responseHeaders} = details;
+    if (documentUrl) {
       for (const regex of regexes[0]) {
         if (documentUrl.match(regex)) {
           return {
@@ -72,7 +72,7 @@ browser.webRequest.onHeadersReceived.addListener(
     }
     return {};
   },
-  { urls: ["<all_urls>"] },
+  { urls: ["<all_urls>"], types: ["sub_frame"] },
   ["blocking", "responseHeaders"]
 );
 


### PR DESCRIPTION
webRequest.RequestFilter doesn't allow filtering by all the fields in the onHeadersReceived details object, but it does support filtering on the "type" field. Since only "sub_frame" requests can be affected by the X-Frame-Options header, we can at least avoid getting called back for all the many other resources that modern web sites love loading.

I expect a solid performance improvement as a result. But then, like my previous patch, I haven't actually tested this or anything. :sweat_smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/anarchist-framer/3)
<!-- Reviewable:end -->
