### PR TITLE
Remove Content-Security-Policy headers as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # <img align="right" src="icon.svg"> Anarchist Framer
 
-Anarchist Framer allows you to strip X-Frame-Options from frames loaded on
-pages you whitelist. This was created for Comic Rocket's reader
+Anarchist Framer allows you to strip X-Frame-Options and
+Content-Security-Policy from frames loaded on pages you whitelist.
+This was created for Comic Rocket's reader
 (`*://www.comic-rocket.com/read/*`), but it should be useful elsewhere.
 
 Anarchist Framer is dual licensed under the Apache License 2.0 and MIT

--- a/background.js
+++ b/background.js
@@ -65,7 +65,8 @@ browser.webRequest.onHeadersReceived.addListener(
       for (const regex of regexes[0]) {
         if (documentUrl.match(regex)) {
           return {
-            responseHeaders: responseHeaders.filter(({name}) => name.toLowerCase() != "x-frame-options"),
+            responseHeaders: responseHeaders.filter(({name}) =>
+                !["x-frame-options", "content-security-policy"].includes(name.toLowerCase())),
           };
         }
       }

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "96": "icon.svg"
   },
 
-  "description": "Strip X-Frame-Options headers from frames loaded on whitelisted pages.",
+  "description": "Strip X-Frame-Options and Content-Security-Policy headers from frames loaded on whitelisted pages.",
   "options_ui": {
     "page": "options.html",
     "browser_style": true,


### PR DESCRIPTION

E.g. content-security-policy: frame-ancestors none
is just as bad as X-Frame-Options: deny

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bb010g/anarchist-framer/4)
<!-- Reviewable:end -->
